### PR TITLE
✨ : 모바일 DND기능 구현, 드래그끝났을때 update() 실행

### DIFF
--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -162,6 +162,7 @@ const Canvas = () => {
   }
 
   const handleMouseUp = () => {
+    updateMarimo()
     setIsDragging(false)
   }
 
@@ -219,6 +220,42 @@ const Canvas = () => {
     console.log("Marimo updated:", data)
   }
 
+  const handleTouchStart = (event: React.TouchEvent<HTMLCanvasElement>) => {
+    const touch = event.touches[0]
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const x = touch.clientX - rect.left // 클릭한 x 좌표를 캔버스 상대 좌표로 변환
+    const y = touch.clientY - rect.top // 클릭한 y 좌표를 캔버스 상대 좌표로 변환
+    if (
+      x > marimoPosition.x &&
+      x < marimoPosition.x + 100 &&
+      y > marimoPosition.y &&
+      y < marimoPosition.y + 100
+    ) {
+      setIsDragging(true)
+      setStartPosition({ x: x - marimoPosition.x, y: y - marimoPosition.y }) // 드래그 시작 위치를 저장
+    }
+  }
+
+  const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    if (!isDragging) return
+    const touch = event.touches[0]
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const x = touch.clientX - rect.left
+    const y = touch.clientY - rect.top
+    const newX = x - startPosition.x
+    const newY = y - startPosition.y
+    setMarimoPosition({ x: newX, y: newY })
+  }
+
+  const handleTouchEnd = () => {
+    updateMarimo()
+    setIsDragging(false)
+  }
+
   useEffect(() => {
     const handleBeforeUnload = async () => {
       // 이벤트의 기본 동작을 막지 않고 업데이트 함수를 바로 호출합니다.
@@ -261,6 +298,9 @@ const Canvas = () => {
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseUp}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
       />
     </div>
   )


### PR DESCRIPTION
## 모바일 DND 기능 구현하였습니다!
- 기존 드래그 코드와 유사하게 touchStart(), touchMove(), touchEnd() 함수를 만들었습니다.

**재밌었던 사실**은 터치는 드래그와 다르게 여러 손가락이 들어올 수 있기에
**드래그**의 경우 **event.clientX** 이렇게 좌표를 추출했다면 
**터치**는 **event.touches[0].clientX** 이렇게 배열을 통해 좌표를 추출한다는 점이 있었습니다!

하지만 마리모의 경우 멀티터치가 크게 필요하지 않기에 [0] 으로만 그냥 할당했습니다!

- 드래그,터치가 끝났을때 화면이 닫길때 update 하는 것 뿐 아니라 더 안전하게 데이터를 update 할 수 있게 구현했습니다.