### PR TITLE
🐛 마리모가 캔버스 밖으로 빠져나가는 버그

### DIFF
--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -155,8 +155,11 @@ const Canvas = () => {
 
     // 드래그 상태일 때만 위치 업데이트
     if (isDragging) {
-      const newX = x - startPosition.x
-      const newY = y - startPosition.y
+      const newX = Math.min(Math.max(0, x - startPosition.x), canvasWidth - 100)
+      const newY = Math.min(
+        Math.max(0, y - startPosition.y),
+        canvasHeight - 100,
+      )
       setMarimoPosition({ x: newX, y: newY })
     }
   }


### PR DESCRIPTION
## 마리모가 캔버스 밖으로 빠져나가는 버그를 픽스했습니다!

최소/최대 좌표 설정: 캔버스의 크기(canvasWidth, canvasHeight)를 고려하여 마리모 이미지의 x, y 좌표의 최소값을 0으로, 최대값을 캔버스의 크기에서 이미지 크기(예시에서는 100px)를 뺀 값으로 설정합니다. 이렇게 하면 이미지가 캔버스의 경계에 정확히 맞춰서 멈추게 됩니다.

드래그 중 좌표 업데이트: 사용자가 이미지를 드래그할 때, 계산된 새 위치(newX, newY)가 위에서 설정한 경계를 넘지 않도록 Math.min과 Math.max 함수를 사용해 조정합니다. 이 함수들은 주어진 값이 특정 범위 내에 있도록 보장합니다. 예를 들어, Math.max(0, x - startPosition.x)는 계산된 x 좌표가 0보다 작아지지 않도록 합니다. 마찬가지로, Math.min(canvasWidth - 100, newX)는 계산된 x 좌표가 캔버스 너비에서 이미지 너비를 뺀 값보다 커지지 않도록 합니다.

이러한 조정을 통해 마리모 이미지가 캔버스 내에서만 움직이도록 제한하며, 사용자가 이미지를 캔버스 경계 너머로 드래그할 수 없게 막습니다. 이 방식으로 UI/UX를 개선하고, 캔버스 밖으로 이미지가 나가는 문제를 해결할 수 있습니다.

- 추후에 100px 에서 실제 마리모의 크기로 동적 할당해주는 작업이 필요합니다!






