### PR TITLE
✨ : 마리모 상태 useState -> useStore 전역변수화 완료했습니다!

### DIFF
--- a/application/usecases/marimo/marimo-usecase.ts
+++ b/application/usecases/marimo/marimo-usecase.ts
@@ -27,9 +27,10 @@ export class MarimoUsecase {
 
   private async createDefaultMarimo(userId: number): Promise<Marimo> {
     const defaultMarimo = {
+      name: "marimo",
       userId: userId,
-      size: 100, // Default size
-      rect: JSON.stringify({ x: 50, y: 50 }), // Default position
+      size: 80,
+      rect: JSON.stringify({ x: 50, y: 50 }),
       color: "dark_green", // Default color
       status: "angry", // Default status
     }

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -8,18 +8,6 @@ import styles from "./index.module.css"
 
 import { useStore } from "@marimo/stores/use-store"
 
-interface MarimoData {
-  user: {
-    id: number
-    name: string
-    userId: number
-    size: number
-    rect: string
-    color: string
-    status: string
-  }
-}
-
 const Canvas = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const marimoImgSrc = "/images/marimo.svg"
@@ -35,13 +23,11 @@ const Canvas = () => {
   const [isDragging, setIsDragging] = useState(false)
   const [startPosition, setStartPosition] = useState({ x: 0, y: 0 })
   const imageRef = useRef(new Image())
-  const { user, trashItems } = useStore()
 
-  const [marimoData, setMarimoData] = useState<MarimoData | null>(null)
-
-  // useEffect(() => {
-  //   console.log("생성된 쓰레기 배열:", trashItems)
-  // }, [trashItems])
+  // zustand 에서 개별로 가져온 데이터, 왜인지 모르게 usestore로 묶어서 가져오면 에러가 나옴,useMemo나 useCallback 을 쓰라고 함
+  const marimo = useStore((state) => state.marimo)
+  const setMarimo = useStore((state) => state.setMarimo)
+  const user = useStore((state) => state.user)
 
   useEffect(() => {
     window.addEventListener("resize", handleCanvasResize)
@@ -58,9 +44,12 @@ const Canvas = () => {
   const loadMarimoImage = () => {
     const marimoImage = imageRef.current
     marimoImage.src = marimoImgSrc
-    marimoImage.onload = () => {
+    ;(marimoImage.onload = () => {
       setImageLoaded(true)
-    }
+    }),
+      (marimoImage.onerror = () => {
+        console.error("Failed to load image") // 이미지 로드 실패 시 로그
+      })
   }
 
   const drawMarimoOnCanvas = () => {
@@ -186,8 +175,9 @@ const Canvas = () => {
       const data = await response.json()
       console.log("fetch data", data)
       // 마리모 데이터를 상태에 저장
-      setMarimoData({
-        ...data,
+
+      setMarimo({
+        ...data.user,
       })
     } catch (error) {
       console.error("API Error:", error)
@@ -200,28 +190,21 @@ const Canvas = () => {
       y: (marimoPosition.y * 100) / canvasHeight,
     })
 
-    // marimoData의 rect 정보를 업데이트
-    const updatedMarimoData = {
-      ...marimoData,
-      user: {
-        ...marimoData?.user,
-        rect: updatedRect,
-      },
-    }
-    const response = await fetch(`/api/marimo/update/${marimoData?.user.id}`, {
+    const response = await fetch(`/api/marimo/update/${marimo?.id}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(updatedMarimoData.user),
+      body: JSON.stringify({ ...marimo, rect: updatedRect }),
     })
+
     if (!response.ok) {
       console.error("Failed to update marimo.")
       return
     }
 
-    const data = await response.json()
-    console.log("Marimo updated:", data)
+    const updatedData = await response.json()
+    setMarimo(updatedData)
   }
 
   const handleTouchStart = (event: React.TouchEvent<HTMLCanvasElement>) => {
@@ -283,13 +266,13 @@ const Canvas = () => {
   }, [user])
 
   useEffect(() => {
-    if (marimoData) {
-      const rectObject = JSON.parse(marimoData.user.rect)
+    if (marimo) {
+      const rectObject = JSON.parse(marimo.rect)
       const percentagedX = (canvasWidth * rectObject.x) / 100
       const percentagedY = (canvasHeight * rectObject.y) / 100
       setMarimoPosition({ x: percentagedX, y: percentagedY })
     }
-  }, [marimoData])
+  }, [marimo])
 
   return (
     <div>

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -11,6 +11,7 @@ import { useStore } from "@marimo/stores/use-store"
 interface MarimoData {
   user: {
     id: number
+    name: string
     userId: number
     size: number
     rect: string
@@ -183,7 +184,7 @@ const Canvas = () => {
         throw new Error("Failed to fetch data")
       }
       const data = await response.json()
-
+      console.log("fetch data", data)
       // 마리모 데이터를 상태에 저장
       setMarimoData({
         ...data,

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -157,8 +157,12 @@ const Canvas = () => {
   }
 
   const fetchMarimo = async () => {
+    if (!user) {
+      console.error("User is null")
+      return
+    }
     try {
-      const response = await fetch(`/api/marimo/${user?.id}`, {
+      const response = await fetch(`/api/marimo/${user.id}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -183,8 +187,11 @@ const Canvas = () => {
       x: (marimoPosition.x * 100) / canvasWidth,
       y: (marimoPosition.y * 100) / canvasHeight,
     })
-
-    const response = await fetch(`/api/marimo/update/${marimo?.id}`, {
+    if (!marimo) {
+      console.error("Marimo is null")
+      return
+    }
+    const response = await fetch(`/api/marimo/update/${marimo.id}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -45,7 +45,7 @@ const Canvas = () => {
       setImageLoaded(true)
     }),
       (marimoImage.onerror = () => {
-        console.error("Failed to load image") // 이미지 로드 실패 시 로그
+        console.error("Failed to load image")
       })
   }
 
@@ -165,13 +165,10 @@ const Canvas = () => {
         },
         body: JSON.stringify({}),
       })
-      console.log(response)
       if (!response.ok) {
         throw new Error("Failed to fetch data")
       }
       const data = await response.json()
-      console.log("fetch data", data)
-      // 마리모 데이터를 상태에 저장
 
       setMarimo({
         ...data.user,
@@ -255,10 +252,8 @@ const Canvas = () => {
 
   useEffect(() => {
     if (user) {
-      console.log("User data loaded:", user)
       fetchMarimo()
     } else {
-      console.log("User data is not loaded. User is null.")
     }
   }, [user])
 

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -253,7 +253,6 @@ const Canvas = () => {
   useEffect(() => {
     if (user) {
       fetchMarimo()
-    } else {
     }
   }, [user])
 

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -24,10 +24,7 @@ const Canvas = () => {
   const [startPosition, setStartPosition] = useState({ x: 0, y: 0 })
   const imageRef = useRef(new Image())
 
-  // zustand 에서 개별로 가져온 데이터, 왜인지 모르게 usestore로 묶어서 가져오면 에러가 나옴,useMemo나 useCallback 을 쓰라고 함
-  const marimo = useStore((state) => state.marimo)
-  const setMarimo = useStore((state) => state.setMarimo)
-  const user = useStore((state) => state.user)
+  const { user, marimo, setMarimo, trashItems } = useStore()
 
   useEffect(() => {
     window.addEventListener("resize", handleCanvasResize)

--- a/domain/repositories/marimo-repository.ts
+++ b/domain/repositories/marimo-repository.ts
@@ -7,6 +7,7 @@ export interface MarimoRepository {
     marimoData: Omit<Marimo, "createdAt" | "updatedAt">,
   ): Promise<Marimo | null>
   createDefaultMarimo(defaultMarimo: {
+    name: string
     userId: number
     size: number
     rect: string

--- a/infrastructure/repositories/pg-marimo-repository.ts
+++ b/infrastructure/repositories/pg-marimo-repository.ts
@@ -43,6 +43,7 @@ export class PgMarimoRepository implements MarimoRepository {
     }
   }
   async createDefaultMarimo(defaultMarimo: {
+    name: string
     userId: number
     size: number
     rect: string

--- a/stores/marimo-store.ts
+++ b/stores/marimo-store.ts
@@ -1,0 +1,30 @@
+import type { StateCreator } from "zustand"
+
+import { State } from "@marimo/stores/use-store"
+
+export type TMarimo = {
+  id: number
+  name: string
+  userId: number
+  size: number
+  rect: string
+  color: string
+  status: string
+}
+
+export type TMarimoSlice = {
+  marimo: TMarimo | null
+  setMarimo: (marimo: TMarimo) => void
+}
+
+// Zustand 스토어 생성을 위한 설정
+export const createMarimoSlice: StateCreator<
+  Partial<State>,
+  [],
+  [],
+  TMarimoSlice
+> = (set) => ({
+  marimo: null,
+
+  setMarimo: (marimo: TMarimo) => set({ marimo }),
+})

--- a/stores/use-store.ts
+++ b/stores/use-store.ts
@@ -4,6 +4,7 @@ import { create } from "zustand"
 import { createSelectorFunctions } from "auto-zustand-selectors-hook"
 import { TTrashSlice, useTrashStore } from "@marimo/stores/trash-store"
 import { createUserSlice, TUserSlice } from "@marimo/stores/user-store"
+import { TMarimoSlice, createMarimoSlice } from "@marimo/stores/marimo-store"
 import {
   persist,
   createJSONStorage,
@@ -23,21 +24,28 @@ const storage: StateStorage = {
   },
 }
 
-export type State = TUserSlice & TTrashSlice
+export type State = TUserSlice & TTrashSlice & TMarimoSlice
 
 export const useStore = create<State>()(
   subscribeWithSelector(
-    persist((...a) => ({ ...createUserSlice(...a), ...useTrashStore(...a) }), {
-      version: 144,
-      name: "angry_marimo",
-      storage: createJSONStorage(() => storage),
-      partialize: (keys) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { ...persistData } = keys
+    persist(
+      (...a) => ({
+        ...createUserSlice(...a),
+        ...useTrashStore(...a),
+        ...createMarimoSlice(...a),
+      }),
+      {
+        version: 144,
+        name: "angry_marimo",
+        storage: createJSONStorage(() => storage),
+        partialize: (keys) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { ...persistData } = keys
 
-        return persistData
+          return persistData
+        },
       },
-    }),
+    ),
   ),
 )
 


### PR DESCRIPTION
useState로 캔버스 컴포넌트에서만 관리되던 마리모 상태를 zustand의 marimo-store.ts 를 통해 전역변수화하였습니다.

slices pattern 을 활용하여
{ **StateCreator** } 를 이용하여 slice store를 생성하였고 
boundStore 인 **use-store**에서 통합하여 상태를 관리하게 되었습니다!

zustand 내장 미들웨어 '**persist**' 를 이용하여 **로컬스토리지에** 마리모 object가 저장됩니다.
