### PR TITLE
🚑 : Object와 Canvas의 일부 로직을 개선하였습니다.

### DIFF
--- a/app/api/marimo/route.ts
+++ b/app/api/marimo/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { PrismaClient } from "@prisma/client"
+import { UserUsecase } from "@marimo/application/usecases/auth/user-usecase"
+import { MarimoUsecase } from "@marimo/application/usecases/marimo/marimo-usecase"
+import {
+  PgMarimoRepository,
+  PgObjectRepository,
+  PgUserRepository,
+} from "@marimo/infrastructure/repositories"
+
+export async function GET(req: NextRequest) {
+  const cookieStore = req.cookies
+  const token = cookieStore.get("token")?.value
+
+  if (!token)
+    return NextResponse.json({ message: "login failed" }, { status: 401 })
+
+  const userUsecase = new UserUsecase(new PgUserRepository(new PrismaClient()))
+
+  const user = await userUsecase.getUser(token)
+
+  if (!user)
+    return NextResponse.json({ message: "user not found" }, { status: 403 })
+
+  const marimoUsecase = new MarimoUsecase(
+    new PgMarimoRepository(),
+    new PgObjectRepository(new PrismaClient()),
+  )
+
+  const marimo = await marimoUsecase.ensureAliveMarimo(user.id)
+
+  return NextResponse.json(marimo, { status: 200 })
+}

--- a/app/api/objects/route.ts
+++ b/app/api/objects/route.ts
@@ -79,23 +79,22 @@ export async function PUT(request: NextRequest) {
       return NextResponse.json({ error: "Empty request body" }, { status: 400 })
     }
 
-    const { id } = body
+    const { idList } = body
 
-    if (!id) {
+    if (!idList) {
       return NextResponse.json(
         { error: "Invalid data format" },
         { status: 400 },
       )
     }
 
-    const repository = new PgObjectRepository(new PrismaClient())
-    const existingObject = await repository.update(id)
+    const objectUsecase = new TrashToObjectUseCase(
+      new PgObjectRepository(new PrismaClient()),
+    )
 
-    if (!existingObject) {
-      return NextResponse.json({ error: "Object not found" }, { status: 404 })
-    }
+    const failedObjects = await objectUsecase.updateMany(idList)
 
-    return NextResponse.json({ success: true }, { status: 200 })
+    return NextResponse.json(failedObjects, { status: 200 })
   } catch (error) {
     return NextResponse.json(
       { error: "Failed to update object" },

--- a/application/usecases/object/trash-object-usecase.ts
+++ b/application/usecases/object/trash-object-usecase.ts
@@ -1,3 +1,4 @@
+import { Object as IObject } from "@prisma/client"
 import { ObjectRepository } from "@marimo/domain/repositories"
 import { InputJsonValue } from "@prisma/client/runtime/client"
 import { IObjectDto } from "@marimo/application/usecases/object/dto/object-dto"
@@ -60,5 +61,25 @@ export class TrashToObjectUseCase {
     }))
 
     return this.objectRepository.createAll(formattedItems)
+  }
+
+  async updateMany(idList: number[]): Promise<IObject[]> {
+    try {
+      const updatedObjects: IObject[] = []
+
+      Promise.all(
+        idList.map(async (id: number) => {
+          const updatedObject = await this.objectRepository.update(id, false)
+
+          if (!updatedObject) return
+
+          updatedObjects.push(updatedObject)
+        }),
+      )
+
+      return updatedObjects.filter((item) => item.isActive)
+    } catch (error) {
+      throw new Error(`TrashToObjectUseCase.execute error: ${error}`)
+    }
   }
 }

--- a/components/canvas/index.module.css
+++ b/components/canvas/index.module.css
@@ -7,20 +7,19 @@
   height: 100%;
 
   position: fixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .common_button {
   padding: 1rem;
   border-radius: 1rem;
 
-  position: absolute;
-  top: 40%;
-  left: 40%;
-
   background: var(--secondary-color);
-
   cursor: pointer;
 }
+
 
 .common_button:hover {
   background: var(--primary-color);

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -11,68 +11,169 @@ import { remToPx } from "@marimo/utils/rem-to-px"
 import styles from "@marimo/components/canvas/index.module.css"
 
 import { useStore } from "@marimo/stores/use-store"
-import { ITrashDto } from "@marimo/application/usecases/object/dto/trash-dto"
-
-interface ILoadedTrashImage extends ITrashDto {
-  image: HTMLImageElement
-}
 
 const Canvas = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
   const [canvasWidth, setCanvasWidth] = useState(window.innerWidth)
   const [canvasHeight, setCanvasHeight] = useState(window.innerHeight)
+
   const [marimoImageLoaded, setMarimoImageLoaded] = useState(false)
-  const [loadedTrashImages, setLoadedTrashImages] = useState<
-    ILoadedTrashImage[]
-  >([])
 
   const [marimoPosition, setMarimoPosition] = useState<{
     x: number
     y: number
   } | null>(null)
-  const [isDragging, setIsDragging] = useState(false)
+
   const [startPosition, setStartPosition] = useState({ x: 0, y: 0 })
   const imageRef = useRef(new Image())
+
   const [bounce, setBounce] = useState(0)
   const [velocity, setVelocity] = useState(0.5)
+  const [marimoSizePx, setMarimoSizePx] = useState(80)
+
+  const [isDragging, setIsDragging] = useState(false)
+  const [isEscape, setIsEscape] = useState<boolean>(false)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
   const {
-    user,
     marimo,
     setMarimo,
     trashItems,
     closeActive,
     marimoImgSrc,
+    loadedTrashImages,
     updateMarimoStatusAndImgSrc,
     resetMarimoPosition,
     fetchMarimoStatus,
     adoptMarimo,
     setImages,
     resetImages,
+    fetchActive,
   } = useStore()
-  const [marimoSizePx, setMarimoSizePx] = useState(80)
 
-  const [isEscape, setIsEscape] = useState<boolean>(false)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
-
+  // window가 새로고침 혹은 닫히기 전 현재 마리모 상태를 저장
   useEffect(() => {
+    const handleBeforeUnload = async () => {
+      await updateMarimo()
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload)
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload)
+      resetImages()
+    }
+  }, [])
+
+  // canvas resize
+  useEffect(() => {
+    const handleCanvasResize = () => {
+      setCanvasWidth(window.innerWidth)
+      setCanvasHeight(window.innerHeight)
+    }
+
     window.addEventListener("resize", handleCanvasResize)
     return () => {
       window.removeEventListener("resize", handleCanvasResize)
     }
   }, [])
 
+  // 화면이 mount 되기 전 marimo를 가져옴
   useEffect(() => {
-    if (!marimo || !marimo.size) return
-    const newSize = remToPx(marimo.size, canvasWidth)
-    setMarimoSizePx(newSize)
+    const fetchMarimo = async () => {
+      try {
+        const response = await fetch(`/api/marimo/`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch data")
+        }
+
+        const data = await response.json()
+
+        const marimoImageResponse = await fetch(
+          `/api/marimo/images/${data.id}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        )
+
+        if (!marimoImageResponse.ok) {
+          throw new Error("Failed to marimoImageResponse fetch data")
+        }
+
+        const images = await marimoImageResponse.json()
+
+        if (images) {
+          const { angry, dead, leftTwerk, rightTwerk } = images
+          setImages(angry, dead, leftTwerk, rightTwerk)
+        }
+
+        setMarimo({
+          ...data,
+        })
+
+        updateMarimoStatusAndImgSrc()
+        fetchMarimoStatus()
+      } catch (error) {
+        console.error("API Error:", error)
+      }
+    }
+
+    fetchMarimo()
+  }, [])
+
+  // marimo size
+  useEffect(() => {
+    if (marimo) {
+      const newSize = remToPx(marimo.size, canvasWidth)
+      if (newSize !== marimoSizePx) setMarimoSizePx(newSize)
+    }
   }, [marimo?.size, canvasWidth])
 
-  const handleCanvasResize = () => {
-    setCanvasWidth(window.innerWidth)
-    setCanvasHeight(window.innerHeight)
-  }
+  // set marimo position
+  useEffect(() => {
+    if (marimo && marimo.rect) {
+      const rectObject = JSON.parse(marimo.rect)
+      const percentagedX = (canvasWidth * rectObject.x) / 100
+      const percentagedY = (canvasHeight * rectObject.y) / 100
+      setMarimoPosition({ x: percentagedX, y: percentagedY })
+    }
+  }, [marimo])
 
+  // marimo image load
+  useEffect(() => {
+    if (!marimoImgSrc) return
+
+    const loadMarimoImage = () => {
+      const marimoImage = imageRef.current
+      marimoImage.src = marimoImgSrc
+      marimoImage.onload = () => setMarimoImageLoaded(true)
+      marimoImage.onerror = () => console.error("Failed to load image")
+    }
+
+    loadMarimoImage()
+  }, [marimoImgSrc])
+
+  // trashItems
+  useEffect(() => {
+    if (!marimo) return
+    // trashItems 개수에 따라 marimo의 상태와 이미지 변경
+    if (trashItems.length === 30 || trashItems.length === 0) {
+      updateMarimoStatusAndImgSrc()
+      fetchMarimoStatus()
+    }
+  }, [trashItems.length])
+
+  // marimo bounce animation
   const animateMarimo = () => {
     if (marimo?.status === "dead") {
       setBounce(0) // 죽은 상태일 때 bounce 제거
@@ -92,41 +193,24 @@ const Canvas = () => {
   }
 
   useEffect(() => {
-    updateMarimoStatusAndImgSrc()
-    fetchMarimoStatus()
-  }, [trashItems?.length])
-
-  useEffect(() => {
     if (!isDragging) {
       const animationFrameId = requestAnimationFrame(animateMarimo)
       return () => cancelAnimationFrame(animationFrameId)
     }
   }, [isDragging, bounce, velocity])
 
-  const loadMarimoImage = () => {
-    const marimoImage = imageRef.current
-    marimoImage.src = marimoImgSrc
-    marimoImage.onload = () => setMarimoImageLoaded(true)
-    marimoImage.onerror = () => console.error("Failed to load image")
+  const isColliding = (
+    marimoPosition: { x: number; y: number },
+    trashPosition: { x: number; y: number; width: number; height: number },
+  ) => {
+    if (!marimo) return
+    return !(
+      marimoPosition.x + marimoSizePx < trashPosition.x ||
+      marimoPosition.x > trashPosition.x + trashPosition.width ||
+      marimoPosition.y + marimoSizePx < trashPosition.y ||
+      marimoPosition.y > trashPosition.y + trashPosition.height
+    )
   }
-  const loadTrashImages = () => {
-    if (!trashItems) return
-    setLoadedTrashImages([])
-    trashItems.forEach((item) => {
-      const img = new Image()
-      img.src = item.url
-      img.onload = () =>
-        setLoadedTrashImages((prev) => [...prev, { ...item, image: img }])
-    })
-  }
-
-  useEffect(() => {
-    loadMarimoImage()
-  }, [marimoImgSrc])
-
-  useEffect(() => {
-    loadTrashImages()
-  }, [trashItems])
 
   const drawOnCanvas = () => {
     if (canvasRef.current) {
@@ -167,18 +251,6 @@ const Canvas = () => {
     }
   }
 
-  const isColliding = (
-    marimoPosition: { x: number; y: number },
-    trashPosition: { x: number; y: number; width: number; height: number },
-  ) => {
-    if (!marimo) return
-    return !(
-      marimoPosition.x + marimoSizePx < trashPosition.x ||
-      marimoPosition.x > trashPosition.x + trashPosition.width ||
-      marimoPosition.y + marimoSizePx < trashPosition.y ||
-      marimoPosition.y > trashPosition.y + trashPosition.height
-    )
-  }
   useEffect(() => {
     if (!canvasWidth || !canvasHeight || !marimoPosition) return
 
@@ -194,15 +266,7 @@ const Canvas = () => {
     } else {
       setIsEscape(false)
     }
-  }, [
-    marimoPosition,
-    marimoImageLoaded,
-    loadedTrashImages,
-    canvasWidth,
-    canvasHeight,
-    marimoSizePx,
-    bounce,
-  ])
+  }, [canvasWidth, canvasHeight, marimoPosition])
 
   const handleMouseDown = (event: React.MouseEvent<HTMLCanvasElement>) => {
     const rect = canvasRef.current?.getBoundingClientRect()
@@ -254,66 +318,43 @@ const Canvas = () => {
     }
   }
 
-  const handleMouseUp = () => {
-    updateMarimo()
-    setIsDragging(false)
+  const handleTouchStart = (event: React.TouchEvent<HTMLCanvasElement>) => {
+    const touch = event.touches[0]
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect || !marimo) return
+    const x = touch.clientX - rect.left
+    const y = touch.clientY - rect.top
+
+    if (
+      marimoPosition &&
+      x > marimoPosition.x &&
+      x < marimoPosition.x + marimoSizePx &&
+      y > marimoPosition.y &&
+      y < marimoPosition.y + marimoSizePx
+    ) {
+      setIsDragging(true)
+      setStartPosition({ x: x - marimoPosition.x, y: y - marimoPosition.y })
+    }
   }
 
-  const fetchMarimo = async () => {
-    if (!user) {
-      console.error("User is null")
-      return
-    }
-
-    try {
-      resetImages()
-
-      const response = await fetch(`/api/marimo/${user.id}`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      })
-
-      if (!response.ok) {
-        throw new Error("Failed to fetch data")
-      }
-      const data = await response.json()
-
-      const marimoImageResponse = await fetch(
-        `/api/marimo/images/${data.user.id}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        },
-      )
-
-      if (!marimoImageResponse.ok) {
-        throw new Error("Failed to marimoImageResponse fetch data")
-      }
-
-      const images = await marimoImageResponse.json()
-
-      if (images) {
-        const { angry, dead, leftTwerk, rightTwerk } = images
-        setImages(angry, dead, leftTwerk, rightTwerk)
-      }
-
-      setMarimo({
-        ...data.user,
-      })
-
-      updateMarimoStatusAndImgSrc()
-      fetchMarimoStatus()
-    } catch (error) {
-      console.error("API Error:", error)
-    }
+  const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current
+    if (!canvas || !marimo || !isDragging) return
+    const touch = event.touches[0]
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const x = touch.clientX - rect.left
+    const y = touch.clientY - rect.top
+    const newX = x - startPosition.x
+    const newY = y - startPosition.y
+    setMarimoPosition({ x: newX, y: newY })
   }
 
   const updateMarimo = async () => {
     if (!marimoPosition) return
+
+    fetchActive()
+
     const updatedRect = JSON.stringify({
       x: (marimoPosition.x * 100) / canvasWidth,
       y: (marimoPosition.y * 100) / canvasHeight,
@@ -339,70 +380,11 @@ const Canvas = () => {
     setMarimo(updatedData)
   }
 
-  const handleTouchStart = (event: React.TouchEvent<HTMLCanvasElement>) => {
-    const touch = event.touches[0]
-    const rect = canvasRef.current?.getBoundingClientRect()
-    if (!rect || !marimo) return
-    const x = touch.clientX - rect.left
-    const y = touch.clientY - rect.top
-
-    if (
-      marimoPosition &&
-      x > marimoPosition.x &&
-      x < marimoPosition.x + marimoSizePx &&
-      y > marimoPosition.y &&
-      y < marimoPosition.y + marimoSizePx
-    ) {
-      setIsDragging(true)
-      setStartPosition({ x: x - marimoPosition.x, y: y - marimoPosition.y })
-    }
-  }
-
-  const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    if (!isDragging) return
-    const touch = event.touches[0]
-    const rect = canvasRef.current?.getBoundingClientRect()
-    if (!rect) return
-    const x = touch.clientX - rect.left
-    const y = touch.clientY - rect.top
-    const newX = x - startPosition.x
-    const newY = y - startPosition.y
-    setMarimoPosition({ x: newX, y: newY })
-  }
-
-  const handleTouchEnd = () => {
-    updateMarimo()
+  // DragEnd
+  const handleDragEnd = () => {
     setIsDragging(false)
+    updateMarimo()
   }
-
-  useEffect(() => {
-    const handleBeforeUnload = async () => {
-      await updateMarimo()
-    }
-
-    window.addEventListener("beforeunload", handleBeforeUnload)
-
-    return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (user) {
-      fetchMarimo()
-    }
-  }, [user])
-
-  useEffect(() => {
-    if (marimo && marimo.rect) {
-      const rectObject = JSON.parse(marimo.rect)
-      const percentagedX = (canvasWidth * rectObject.x) / 100
-      const percentagedY = (canvasHeight * rectObject.y) / 100
-      setMarimoPosition({ x: percentagedX, y: percentagedY })
-    }
-  }, [marimo])
 
   return (
     <div>
@@ -439,6 +421,7 @@ const Canvas = () => {
           </button>
         </div>
       )}
+
       <canvas
         ref={canvasRef}
         className={styles.canvas}
@@ -446,11 +429,11 @@ const Canvas = () => {
         height={canvasHeight}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseUp}
+        onMouseUp={handleDragEnd}
+        onMouseLeave={handleDragEnd}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
+        onTouchEnd={handleDragEnd}
       />
     </div>
   )

--- a/components/canvas/index.tsx
+++ b/components/canvas/index.tsx
@@ -27,7 +27,6 @@ const Canvas = () => {
 
   const [startPosition, setStartPosition] = useState({ x: 0, y: 0 })
   const imageRef = useRef(new Image())
-
   const [bounce, setBounce] = useState(0)
   const [velocity, setVelocity] = useState(0.5)
   const [marimoSizePx, setMarimoSizePx] = useState(80)
@@ -46,132 +45,32 @@ const Canvas = () => {
     updateMarimoStatusAndImgSrc,
     resetMarimoPosition,
     fetchMarimoStatus,
+    setTrashItems,
     adoptMarimo,
     setImages,
     resetImages,
     fetchActive,
   } = useStore()
 
-  // window가 새로고침 혹은 닫히기 전 현재 마리모 상태를 저장
-  useEffect(() => {
-    const handleBeforeUnload = async () => {
-      await updateMarimo()
-    }
-
-    window.addEventListener("beforeunload", handleBeforeUnload)
-
-    return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload)
-      resetImages()
-    }
-  }, [])
-
   // canvas resize
+  const handleCanvasResize = () => {
+    setCanvasWidth(window.innerWidth)
+    setCanvasHeight(window.innerHeight)
+  }
   useEffect(() => {
-    const handleCanvasResize = () => {
-      setCanvasWidth(window.innerWidth)
-      setCanvasHeight(window.innerHeight)
-    }
-
     window.addEventListener("resize", handleCanvasResize)
     return () => {
+      resetImages()
       window.removeEventListener("resize", handleCanvasResize)
     }
   }, [])
 
-  // 화면이 mount 되기 전 marimo를 가져옴
-  useEffect(() => {
-    const fetchMarimo = async () => {
-      try {
-        const response = await fetch(`/api/marimo/`, {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        })
-
-        if (!response.ok) {
-          throw new Error("Failed to fetch data")
-        }
-
-        const data = await response.json()
-
-        const marimoImageResponse = await fetch(
-          `/api/marimo/images/${data.id}`,
-          {
-            method: "GET",
-            headers: {
-              "Content-Type": "application/json",
-            },
-          },
-        )
-
-        if (!marimoImageResponse.ok) {
-          throw new Error("Failed to marimoImageResponse fetch data")
-        }
-
-        const images = await marimoImageResponse.json()
-
-        if (images) {
-          const { angry, dead, leftTwerk, rightTwerk } = images
-          setImages(angry, dead, leftTwerk, rightTwerk)
-        }
-
-        setMarimo({
-          ...data,
-        })
-
-        updateMarimoStatusAndImgSrc()
-        fetchMarimoStatus()
-      } catch (error) {
-        console.error("API Error:", error)
-      }
-    }
-
-    fetchMarimo()
-  }, [])
-
   // marimo size
   useEffect(() => {
-    if (marimo) {
-      const newSize = remToPx(marimo.size, canvasWidth)
-      if (newSize !== marimoSizePx) setMarimoSizePx(newSize)
-    }
+    if (!marimo || !marimo.size) return
+    const newSize = remToPx(marimo.size, canvasWidth)
+    setMarimoSizePx(newSize)
   }, [marimo?.size, canvasWidth])
-
-  // set marimo position
-  useEffect(() => {
-    if (marimo && marimo.rect) {
-      const rectObject = JSON.parse(marimo.rect)
-      const percentagedX = (canvasWidth * rectObject.x) / 100
-      const percentagedY = (canvasHeight * rectObject.y) / 100
-      setMarimoPosition({ x: percentagedX, y: percentagedY })
-    }
-  }, [marimo])
-
-  // marimo image load
-  useEffect(() => {
-    if (!marimoImgSrc) return
-
-    const loadMarimoImage = () => {
-      const marimoImage = imageRef.current
-      marimoImage.src = marimoImgSrc
-      marimoImage.onload = () => setMarimoImageLoaded(true)
-      marimoImage.onerror = () => console.error("Failed to load image")
-    }
-
-    loadMarimoImage()
-  }, [marimoImgSrc])
-
-  // trashItems
-  useEffect(() => {
-    if (!marimo) return
-    // trashItems 개수에 따라 marimo의 상태와 이미지 변경
-    if (trashItems.length === 30 || trashItems.length === 0) {
-      updateMarimoStatusAndImgSrc()
-      fetchMarimoStatus()
-    }
-  }, [trashItems.length])
 
   // marimo bounce animation
   const animateMarimo = () => {
@@ -191,7 +90,6 @@ const Canvas = () => {
       requestAnimationFrame(animateMarimo)
     }
   }
-
   useEffect(() => {
     if (!isDragging) {
       const animationFrameId = requestAnimationFrame(animateMarimo)
@@ -199,19 +97,31 @@ const Canvas = () => {
     }
   }, [isDragging, bounce, velocity])
 
-  const isColliding = (
-    marimoPosition: { x: number; y: number },
-    trashPosition: { x: number; y: number; width: number; height: number },
-  ) => {
-    if (!marimo) return
-    return !(
-      marimoPosition.x + marimoSizePx < trashPosition.x ||
-      marimoPosition.x > trashPosition.x + trashPosition.width ||
-      marimoPosition.y + marimoSizePx < trashPosition.y ||
-      marimoPosition.y > trashPosition.y + trashPosition.height
-    )
-  }
+  // trashItems의 개수에 따라 zustand.marimo의 status 및 이미지 변경
+  useEffect(() => {
+    updateMarimoStatusAndImgSrc()
+  }, [trashItems?.length])
 
+  // status가 변경 될 때만 fetch
+  useEffect(() => {
+    if (!marimo) return
+    fetchMarimoStatus()
+  }, [marimo?.status])
+
+  // 마리모 이미지 로드
+  const loadMarimoImage = () => {
+    if (!marimoImgSrc) return
+
+    const marimoImage = imageRef.current
+    marimoImage.src = marimoImgSrc
+    marimoImage.onload = () => setMarimoImageLoaded(true)
+    marimoImage.onerror = () => console.error("Failed to load image")
+  }
+  useEffect(() => {
+    loadMarimoImage()
+  }, [marimoImgSrc])
+
+  // 캔버스 그리기
   const drawOnCanvas = () => {
     if (canvasRef.current) {
       const canvas = canvasRef.current
@@ -250,7 +160,18 @@ const Canvas = () => {
       }
     }
   }
-
+  const isColliding = (
+    marimoPosition: { x: number; y: number },
+    trashPosition: { x: number; y: number; width: number; height: number },
+  ) => {
+    if (!marimo) return
+    return !(
+      marimoPosition.x + marimoSizePx < trashPosition.x ||
+      marimoPosition.x > trashPosition.x + trashPosition.width ||
+      marimoPosition.y + marimoSizePx < trashPosition.y ||
+      marimoPosition.y > trashPosition.y + trashPosition.height
+    )
+  }
   useEffect(() => {
     if (!canvasWidth || !canvasHeight || !marimoPosition) return
 
@@ -266,7 +187,90 @@ const Canvas = () => {
     } else {
       setIsEscape(false)
     }
-  }, [canvasWidth, canvasHeight, marimoPosition])
+  }, [
+    marimoPosition,
+    marimoImageLoaded,
+    loadedTrashImages,
+    canvasWidth,
+    canvasHeight,
+    marimoSizePx,
+    bounce,
+  ])
+
+  // window가 새로고침 혹은 닫히기 전 현재 마리모 상태를 저장
+  useEffect(() => {
+    const handleBeforeUnload = async () => {
+      await updateMarimo()
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload)
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload)
+    }
+  }, [])
+
+  // 마리모 fetch
+  useEffect(() => {
+    const fetchMarimo = async () => {
+      try {
+        const response = await fetch(`/api/marimo/`, {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+
+        if (!response.ok) {
+          throw new Error("Failed to fetch data")
+        }
+
+        const data = await response.json()
+
+        const marimoImageResponse = await fetch(
+          `/api/marimo/images/${data.id}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        )
+
+        if (!marimoImageResponse.ok) {
+          throw new Error("Failed to marimoImageResponse fetch data")
+        }
+
+        const images = await marimoImageResponse.json()
+
+        if (images) {
+          const { angry, dead, leftTwerk, rightTwerk } = images
+          setImages(angry, dead, leftTwerk, rightTwerk)
+        }
+
+        setMarimo(data)
+
+        setTrashItems(data.objects)
+
+        updateMarimoStatusAndImgSrc()
+        fetchMarimoStatus()
+      } catch (error) {
+        console.error("API Error:", error)
+      }
+    }
+
+    fetchMarimo()
+  }, [])
+
+  // 마리모 position 변경
+  useEffect(() => {
+    if (marimo && marimo.rect) {
+      const rectObject = JSON.parse(marimo.rect)
+      const percentagedX = (canvasWidth * rectObject.x) / 100
+      const percentagedY = (canvasHeight * rectObject.y) / 100
+      setMarimoPosition({ x: percentagedX, y: percentagedY })
+    }
+  }, [marimo])
 
   const handleMouseDown = (event: React.MouseEvent<HTMLCanvasElement>) => {
     const rect = canvasRef.current?.getBoundingClientRect()
@@ -318,42 +322,10 @@ const Canvas = () => {
     }
   }
 
-  const handleTouchStart = (event: React.TouchEvent<HTMLCanvasElement>) => {
-    const touch = event.touches[0]
-    const rect = canvasRef.current?.getBoundingClientRect()
-    if (!rect || !marimo) return
-    const x = touch.clientX - rect.left
-    const y = touch.clientY - rect.top
-
-    if (
-      marimoPosition &&
-      x > marimoPosition.x &&
-      x < marimoPosition.x + marimoSizePx &&
-      y > marimoPosition.y &&
-      y < marimoPosition.y + marimoSizePx
-    ) {
-      setIsDragging(true)
-      setStartPosition({ x: x - marimoPosition.x, y: y - marimoPosition.y })
-    }
-  }
-
-  const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current
-    if (!canvas || !marimo || !isDragging) return
-    const touch = event.touches[0]
-    const rect = canvasRef.current?.getBoundingClientRect()
-    if (!rect) return
-    const x = touch.clientX - rect.left
-    const y = touch.clientY - rect.top
-    const newX = x - startPosition.x
-    const newY = y - startPosition.y
-    setMarimoPosition({ x: newX, y: newY })
-  }
-
   const updateMarimo = async () => {
     if (!marimoPosition) return
 
-    fetchActive()
+    await fetchActive()
 
     const updatedRect = JSON.stringify({
       x: (marimoPosition.x * 100) / canvasWidth,
@@ -377,7 +349,42 @@ const Canvas = () => {
     }
 
     const updatedData = await response.json()
+    console.log(updatedData)
+
     setMarimo(updatedData)
+  }
+
+  const handleTouchStart = (event: React.TouchEvent<HTMLCanvasElement>) => {
+    const touch = event.touches[0]
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect || !marimo) return
+    const x = touch.clientX - rect.left
+    const y = touch.clientY - rect.top
+
+    if (
+      marimoPosition &&
+      x > marimoPosition.x &&
+      x < marimoPosition.x + marimoSizePx &&
+      y > marimoPosition.y &&
+      y < marimoPosition.y + marimoSizePx
+    ) {
+      setIsDragging(true)
+      setStartPosition({ x: x - marimoPosition.x, y: y - marimoPosition.y })
+    }
+  }
+
+  const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    if (!isDragging) return
+    const touch = event.touches[0]
+    const rect = canvasRef.current?.getBoundingClientRect()
+    if (!rect) return
+    const x = touch.clientX - rect.left
+    const y = touch.clientY - rect.top
+    const newX = x - startPosition.x
+    const newY = y - startPosition.y
+    setMarimoPosition({ x: newX, y: newY })
   }
 
   // DragEnd
@@ -421,7 +428,6 @@ const Canvas = () => {
           </button>
         </div>
       )}
-
       <canvas
         ref={canvasRef}
         className={styles.canvas}

--- a/components/object/object-component.tsx
+++ b/components/object/object-component.tsx
@@ -11,7 +11,7 @@ import { useWindowEvents } from "@marimo/public/utils/use-window-event"
 import { useStore } from "@marimo/stores/use-store"
 
 export const useObjectComponent = () => {
-  const { marimo, isMarimoLoading } = useStore()
+  const { marimo, isMarimoLoading, trashItems } = useStore()
   const { worker, isWorkerRunning, workerLoading, terminateWorker } =
     useWorker()
 
@@ -22,9 +22,24 @@ export const useObjectComponent = () => {
     if (!window || !isWorkerRunning || !worker.current || !marimo) return
 
     const windowHeight = window.innerHeight || 1
+
+    const second = trashItems.length < 15 ? 77000 : 144000
+
     worker.current.postMessage({
+      message: "start",
       windowHeight,
+      second,
     })
+
+    return () => {
+      if (worker.current) {
+        worker.current.postMessage({
+          message: "stop",
+          windowHeight,
+          second,
+        })
+      }
+    }
   }, [isMarimoLoading])
 
   useEffect(() => {

--- a/components/object/object-component.tsx
+++ b/components/object/object-component.tsx
@@ -40,7 +40,7 @@ export const useObjectComponent = () => {
         })
       }
     }
-  }, [isMarimoLoading])
+  }, [trashItems.length, isMarimoLoading])
 
   useEffect(() => {
     workerLoading()

--- a/domain/repositories/object-repository.ts
+++ b/domain/repositories/object-repository.ts
@@ -22,7 +22,7 @@ export interface ObjectRepository {
     }[],
   ): Promise<ObjectItem[]>
 
-  update(id: number, isActive: boolean): Promise<Omit<ObjectItem, "id">>
+  update(id: number, isActive?: boolean): Promise<ObjectItem | null>
 
   findById(id: number): Promise<ObjectItem | null>
 

--- a/infrastructure/repositories/pg-object-repository.ts
+++ b/infrastructure/repositories/pg-object-repository.ts
@@ -11,7 +11,7 @@ export class PgObjectRepository implements ObjectRepository {
       const findById = await this.prisma.object.findUnique({
         where: { id },
       })
-      return findById || null
+      return findById
     } catch (error) {
       throw new Error(`PgObjectRepository.findId.error =========> \n ${error}`)
     } finally {
@@ -19,12 +19,12 @@ export class PgObjectRepository implements ObjectRepository {
     }
   }
 
-  async findAllByMarimoId(marimoId: number): Promise<ObjectItem[] | null> {
+  async findAllByMarimoId(marimoId: number): Promise<ObjectItem[]> {
     try {
       const findByMarimoId = await this.prisma.object.findMany({
         where: { marimoId, isActive: true },
       })
-      return findByMarimoId.length > 0 ? findByMarimoId : null
+      return findByMarimoId
     } catch (error) {
       throw new Error(
         `PgObjectRepository.findAllByMarimoId.error =========> \n ${error}`,
@@ -92,20 +92,27 @@ export class PgObjectRepository implements ObjectRepository {
     }
   }
 
-  async update(id: number): Promise<ObjectItem> {
+  async update(id: number, isActive = false): Promise<ObjectItem | null> {
     try {
       const updateObject = await this.prisma.object.update({
         where: {
           id,
         },
         data: {
-          isActive: false,
+          isActive,
         },
       })
 
+      if (!updateObject) {
+        return this.prisma.object.findUnique({
+          where: { id },
+        })
+      }
       return updateObject
     } catch (error) {
-      throw new Error(`PgObjectRepository.update.error =========> \n ${error}`)
+      return this.prisma.object.findUnique({
+        where: { id },
+      })
     } finally {
       await this.prisma.$disconnect()
     }

--- a/public/utils/use-worker.ts
+++ b/public/utils/use-worker.ts
@@ -37,8 +37,6 @@ export const useWorker = () => {
       { type: "module" },
     )
 
-    if (!marimo || !marimo.id) return
-
     worker.current.onmessage = async (event) => {
       const { data: objectItem } = event
       if ((trashItems?.length || 0) < 30) addTrashItems(objectItem)

--- a/public/workers/object-worker.ts
+++ b/public/workers/object-worker.ts
@@ -3,6 +3,8 @@ import { randomLocation } from "@marimo/public/utils/random-location"
 
 import { HEADER_HEIGHT } from "@marimo/constants/trash-header"
 
+let interval: string | number | NodeJS.Timeout | undefined
+
 self.addEventListener(
   "message",
   (
@@ -14,7 +16,6 @@ self.addEventListener(
   ) => {
     try {
       const { message, windowHeight, second } = event.data
-      let interval: string | number | NodeJS.Timeout | undefined
 
       if (message === "start" && windowHeight && second) {
         const headerHeight = HEADER_HEIGHT

--- a/public/workers/object-worker.ts
+++ b/public/workers/object-worker.ts
@@ -25,7 +25,6 @@ self.addEventListener(
     const startInterval = () => {
       clearInterval(interval)
       interval = setInterval(async () => {
-
         const point = randomLocation(1)[0]
         const level = Math.floor(Math.random() * 3) + 1
 

--- a/public/workers/object-worker.ts
+++ b/public/workers/object-worker.ts
@@ -3,46 +3,51 @@ import { randomLocation } from "@marimo/public/utils/random-location"
 
 import { HEADER_HEIGHT } from "@marimo/constants/trash-header"
 
-import { Marimo } from "@prisma/client"
-
 self.addEventListener(
   "message",
   (
     event: MessageEvent<{
-      itemCount: number
-      marimo: Marimo
-      windowHeight: number
+      message: string
+      windowHeight?: number
+      second?: number
     }>,
   ) => {
-    const { windowHeight } = event.data
-    const headerHeight = HEADER_HEIGHT
+    try {
+      const { message, windowHeight, second } = event.data
+      let interval: string | number | NodeJS.Timeout | undefined
 
-    const second = 1440000
-    let interval: string | number | NodeJS.Timeout | undefined
+      if (message === "start" && windowHeight && second) {
+        const headerHeight = HEADER_HEIGHT
 
-    clearInterval(interval)
+        const startInterval = () => {
+          clearInterval(interval)
+          interval = setInterval(async () => {
+            const point = randomLocation(1)[0]
+            const level = Math.floor(Math.random() * 3) + 1
 
-    const startInterval = () => {
-      clearInterval(interval)
-      interval = setInterval(async () => {
-        const point = randomLocation(1)[0]
-        const level = Math.floor(Math.random() * 3) + 1
+            const newTrashItem = {
+              level,
+              url: getTrashImage(level),
+              rect: {
+                x: point.x * 70,
+                y: point.y * 70 + (headerHeight / windowHeight) * 100,
+              },
+              isActive: true,
+              type: "trash",
+            }
 
-        const newTrashItem = {
-          level,
-          url: getTrashImage(level),
-          rect: {
-            x: point.x * 70,
-            y: point.y * 70 + (headerHeight / windowHeight) * 100,
-          },
-          isActive: true,
-          type: "trash",
+            postMessage(newTrashItem)
+          }, second)
         }
 
-        postMessage(newTrashItem)
-      }, second)
-    }
+        startInterval()
+      }
 
-    startInterval()
+      if (message === "stop") {
+        clearInterval(interval)
+      }
+    } catch (error) {
+      console.error("❌ postMessage error in worker:", error)
+    }
   },
 )

--- a/stores/marimo-store.ts
+++ b/stores/marimo-store.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from "zustand"
 
 import { State } from "@marimo/stores/use-store"
 import { Object as IObject } from "@prisma/client"
+import { ILoadedTrashImage } from "@marimo/stores/trash-store"
 
 export type TMarimo = {
   id: number
@@ -207,23 +208,19 @@ export const createMarimoSlice: StateCreator<
     const marimo = await response.json()
 
     const trashItems = marimo.objects as IObject[]
+    const loadedTrashImages = [] as ILoadedTrashImage[]
 
     trashItems.forEach((item) => {
       const img = new Image()
       img.src = item.url
 
-      img.onload = () =>
-        set((state) => ({
-          loadedTrashImages: [
-            ...(state.loadedTrashImages ?? []),
-            { ...item, image: img },
-          ],
-        }))
+      img.onload = () => loadedTrashImages.push({ ...item, image: img })
     })
 
     set({
       marimo,
       trashItems,
+      loadedTrashImages,
       marimoImgSrc: "/images/marimo.svg",
       marimoSrc: "/images/marimo.svg",
       deadMarimoSrc: "/images/dead-marimo.svg",

--- a/stores/marimo-store.ts
+++ b/stores/marimo-store.ts
@@ -57,27 +57,11 @@ export const createMarimoSlice: StateCreator<
   rightTwerkingMarimoSrc: "/images/right-twerking-marimo.svg",
   intervalId: null as NodeJS.Timeout | null,
 
-  setMarimo: (marimo: TMarimo) => {
-    const trashItems = marimo.objects ?? []
+  setMarimo: (marimo: TMarimo) =>
     set({
       isMarimoLoading: true,
       marimo,
-      trashItems,
-    })
-
-    trashItems.forEach((item) => {
-      const img = new Image()
-      img.src = item.url
-
-      img.onload = () =>
-        set((state) => ({
-          loadedTrashImages: [
-            ...(state.loadedTrashImages ?? []),
-            { ...item, image: img },
-          ],
-        }))
-    })
-  },
+    }),
 
   setImages: (
     marimoSrc = "/images/marimo.svg",
@@ -106,54 +90,57 @@ export const createMarimoSlice: StateCreator<
     }),
 
   updateMarimoStatusAndImgSrc: () => {
-    if (!get().trashItems) return
+    set((state) => {
+      console.log(state.trashItems)
+      const interval = state.intervalId
+      if (interval !== null && interval !== undefined) {
+        clearInterval(interval)
+      }
 
-    const interval = get().intervalId
-    if (interval !== null && interval !== undefined) {
-      clearInterval(interval)
-      set({ intervalId: null })
-    }
+      const length = state.trashItems?.length ?? 0
+      const marimo = state.marimo
 
-    if (get().trashItems?.length === 0) {
-      set({
+      if (!marimo) return { intervalId: null }
+
+      if (length === 0) {
+        let toggle = false
+        const newIntervalId = setInterval(() => {
+          set({
+            marimoImgSrc: toggle
+              ? get().leftTwerkingMarimoSrc
+              : get().rightTwerkingMarimoSrc,
+          })
+          toggle = !toggle
+        }, 500)
+
+        return {
+          marimo: {
+            ...marimo,
+            status: "happy",
+          },
+          intervalId: newIntervalId,
+        }
+      }
+
+      if (length > 30) {
+        return {
+          marimo: {
+            ...marimo,
+            status: "dead",
+          },
+          marimoImgSrc: state.deadMarimoSrc,
+          intervalId: null,
+        }
+      }
+
+      return {
         marimo: {
-          ...(get().marimo as TMarimo),
-          status: "happy",
+          ...marimo,
+          status: "angry",
         },
-      })
-
-      let toggle = false
-      const newIntervalId = setInterval(() => {
-        set({
-          marimoImgSrc: toggle
-            ? get().leftTwerkingMarimoSrc
-            : get().rightTwerkingMarimoSrc,
-        })
-        toggle = !toggle
-      }, 500)
-
-      set({ intervalId: newIntervalId })
-      return
-    }
-
-    if ((get().trashItems?.length as number) > 30) {
-      return set({
-        marimo: {
-          ...(get().marimo as TMarimo),
-          status: "dead",
-        },
-
-        marimoImgSrc: get().deadMarimoSrc,
-      })
-    }
-
-    return set({
-      marimo: {
-        ...(get().marimo as TMarimo),
-        status: "angry",
-      },
-
-      marimoImgSrc: get().marimoSrc,
+        marimoImgSrc: get().marimoSrc,
+        intervalId: null,
+      }
     })
   },
 

--- a/stores/marimo-store.ts
+++ b/stores/marimo-store.ts
@@ -20,11 +20,11 @@ export type TMarimoSlice = {
   marimo: TMarimo | null
   setMarimo: (marimo: TMarimo) => void
 
-  marimoImgSrc: string
-  marimoSrc: string
-  deadMarimoSrc: string
-  leftTwerkingMarimoSrc: string
-  rightTwerkingMarimoSrc: string
+  marimoImgSrc: string | null
+  marimoSrc: string | null
+  deadMarimoSrc: string | null
+  leftTwerkingMarimoSrc: string | null
+  rightTwerkingMarimoSrc: string | null
   intervalId: NodeJS.Timeout | null
 
   resetMarimoPosition: () => void
@@ -50,36 +50,55 @@ export const createMarimoSlice: StateCreator<
 > = (set, get) => ({
   isMarimoLoading: false,
   marimo: null,
-  marimoImgSrc: "/images/marimo.svg",
+  marimoImgSrc: null,
   marimoSrc: "/images/marimo.svg",
   deadMarimoSrc: "/images/dead-marimo.svg",
   leftTwerkingMarimoSrc: "/images/left-twerking-marimo.svg",
   rightTwerkingMarimoSrc: "/images/right-twerking-marimo.svg",
   intervalId: null as NodeJS.Timeout | null,
 
-  setMarimo: (marimo: TMarimo) =>
-    set({ isMarimoLoading: true, marimo, trashItems: marimo.objects }),
+  setMarimo: (marimo: TMarimo) => {
+    const trashItems = marimo.objects ?? []
+    set({
+      isMarimoLoading: true,
+      marimo,
+      trashItems,
+    })
+
+    trashItems.forEach((item) => {
+      const img = new Image()
+      img.src = item.url
+
+      img.onload = () =>
+        set((state) => ({
+          loadedTrashImages: [
+            ...(state.loadedTrashImages ?? []),
+            { ...item, image: img },
+          ],
+        }))
+    })
+  },
 
   setImages: (
-    marimoSrc,
-    deadMarimoSrc,
-    leftTwerkingMarimoSrc,
-    rightTwerkingMarimoSrc,
+    marimoSrc = "/images/marimo.svg",
+    deadMarimoSrc = "/images/dead-marimo.svg",
+    leftTwerkingMarimoSrc = "/images/left-twerking-marimo.svg",
+    rightTwerkingMarimoSrc = "/images/right-twerking-marimo.svg",
   ) =>
-    set({
+    set((state) => ({
       marimo: {
-        ...(get().marimo as TMarimo),
+        ...(state as TMarimo),
         src: marimoSrc,
       },
       marimoSrc,
       deadMarimoSrc,
       leftTwerkingMarimoSrc,
       rightTwerkingMarimoSrc,
-    }),
+    })),
 
   resetImages: () =>
     set({
-      marimoImgSrc: "/images/marimo.svg",
+      marimoImgSrc: null,
       marimoSrc: "/images/marimo.svg",
       deadMarimoSrc: "/images/dead-marimo.svg",
       leftTwerkingMarimoSrc: "/images/left-twerking-marimo.svg",
@@ -96,7 +115,6 @@ export const createMarimoSlice: StateCreator<
     }
 
     if (get().trashItems?.length === 0) {
-      console.log("store --->", get().marimo)
       set({
         marimo: {
           ...(get().marimo as TMarimo),
@@ -201,9 +219,24 @@ export const createMarimoSlice: StateCreator<
 
     const marimo = await response.json()
 
+    const trashItems = marimo.objects as IObject[]
+
+    trashItems.forEach((item) => {
+      const img = new Image()
+      img.src = item.url
+
+      img.onload = () =>
+        set((state) => ({
+          loadedTrashImages: [
+            ...(state.loadedTrashImages ?? []),
+            { ...item, image: img },
+          ],
+        }))
+    })
+
     set({
       marimo,
-      trashItems: marimo.objects,
+      trashItems,
       marimoImgSrc: "/images/marimo.svg",
       marimoSrc: "/images/marimo.svg",
       deadMarimoSrc: "/images/dead-marimo.svg",

--- a/stores/trash-store.ts
+++ b/stores/trash-store.ts
@@ -12,11 +12,13 @@ export type TTrash = {
 }
 
 export interface TTrashSlice {
-  trashItems: TTrash[] | null
+  trashItems: TTrash[]
+  closedItemIds: number[]
 
   setTrashItems: (trashItems: TTrash[]) => void
   addTrashItems: (item: TTrash) => void
   closeActive: (id: number) => void
+  fetchActive: () => Promise<void>
 }
 
 export const useTrashStore: StateCreator<
@@ -26,6 +28,7 @@ export const useTrashStore: StateCreator<
   TTrashSlice
 > = (set, get) => ({
   trashItems: [],
+  closedItemIds: [],
 
   setTrashItems: (trashItems: TTrash[]) => set({ trashItems }),
 
@@ -59,22 +62,19 @@ export const useTrashStore: StateCreator<
     }
   },
 
-  closeActive: async (id: number) => {
-    console.log("here --->", id)
-    console.log("here1 --->", get().trashItems)
+  closeActive: (id: number) => {
     if (!id) return
 
-    const prevItem = get().trashItems?.find((item) => item.id === id)
-
-    if (!prevItem) return
-
-    console.log("here2 --->", get().trashItems)
-
-    set({
+    set((state) => ({
+      closedItemIds: [...(state.closedItemIds ?? []), id],
       trashItems: [
-        ...(get().trashItems ?? []).filter((item) => item.id !== id),
+        ...(state.trashItems ?? []).filter((item) => item.id !== id),
       ],
-    })
+    }))
+  },
+
+  fetchActive: async () => {
+    const idList = get().closedItemIds
 
     const response = await fetch(`/api/objects`, {
       method: "PUT",
@@ -82,12 +82,19 @@ export const useTrashStore: StateCreator<
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        id,
+        idList,
       }),
     })
 
     if (!response.ok) {
-      set({ trashItems: [...(get().trashItems ?? []), prevItem] })
+      console.error("zustand trash-store fetchActive error")
     }
+
+    const failedObjects = await response.json()
+
+    set((state) => ({
+      closedItemIds: [],
+      trashItems: [...(state.trashItems ?? []), ...failedObjects],
+    }))
   },
 })

--- a/stores/trash-store.ts
+++ b/stores/trash-store.ts
@@ -38,7 +38,22 @@ export const useTrashStore: StateCreator<
   loadedTrashImages: [],
   closedItemIds: [],
 
-  setTrashItems: (trashItems: TTrash[]) => set({ trashItems }),
+  setTrashItems: (trashItems: TTrash[]) => {
+    set({ trashItems })
+
+    trashItems.forEach((item) => {
+      const img = new Image()
+      img.src = item.url
+
+      img.onload = () =>
+        set((state) => ({
+          loadedTrashImages: [
+            ...(state.loadedTrashImages ?? []),
+            { ...item, image: img },
+          ],
+        }))
+    })
+  },
 
   addTrashItems: async (newTrashItem) => {
     if (!get().marimo) return
@@ -112,10 +127,12 @@ export const useTrashStore: StateCreator<
 
     const failedObjects = (await response.json()) as IObject[]
 
-    set((state) => ({
-      closedItemIds: [],
-      trashItems: [...(state.trashItems ?? []), ...failedObjects],
-    }))
+    set((state) => {
+      return {
+        closedItemIds: [],
+        trashItems: [...(state.trashItems ?? []), ...failedObjects],
+      }
+    })
 
     failedObjects.forEach((item) => {
       const img = new Image()

--- a/stores/trash-store.ts
+++ b/stores/trash-store.ts
@@ -1,6 +1,12 @@
 import { StateCreator } from "zustand"
 import { State } from "@marimo/stores/use-store"
+import { Object as IObject } from "@prisma/client"
 import { JsonValue } from "@prisma/client/runtime/client"
+import { ITrashDto } from "@marimo/application/usecases/object/dto/trash-dto"
+
+interface ILoadedTrashImage extends ITrashDto {
+  image: HTMLImageElement
+}
 
 export type TTrash = {
   id: number
@@ -13,6 +19,7 @@ export type TTrash = {
 
 export interface TTrashSlice {
   trashItems: TTrash[]
+  loadedTrashImages: ILoadedTrashImage[]
   closedItemIds: number[]
 
   setTrashItems: (trashItems: TTrash[]) => void
@@ -28,6 +35,7 @@ export const useTrashStore: StateCreator<
   TTrashSlice
 > = (set, get) => ({
   trashItems: [],
+  loadedTrashImages: [],
   closedItemIds: [],
 
   setTrashItems: (trashItems: TTrash[]) => set({ trashItems }),
@@ -54,9 +62,18 @@ export const useTrashStore: StateCreator<
 
       const data = await response.json()
       const objectItem = data.objectItem
-      const trashItems = [...(get().trashItems ?? []), objectItem]
 
-      set({ trashItems })
+      const img = new Image()
+      img.src = objectItem.url
+
+      img.onload = () =>
+        set((state) => ({
+          trashItems: [...(state.trashItems ?? []), objectItem],
+          loadedTrashImages: [
+            ...(state.loadedTrashImages ?? []),
+            { ...objectItem, image: img },
+          ],
+        }))
     } catch (error) {
       console.error("❌ API 전송 중 오류 발생:", error)
     }
@@ -69,6 +86,9 @@ export const useTrashStore: StateCreator<
       closedItemIds: [...(state.closedItemIds ?? []), id],
       trashItems: [
         ...(state.trashItems ?? []).filter((item) => item.id !== id),
+      ],
+      loadedTrashImages: [
+        ...(state.loadedTrashImages ?? []).filter((item) => item.id !== id),
       ],
     }))
   },
@@ -90,11 +110,24 @@ export const useTrashStore: StateCreator<
       console.error("zustand trash-store fetchActive error")
     }
 
-    const failedObjects = await response.json()
+    const failedObjects = (await response.json()) as IObject[]
 
     set((state) => ({
       closedItemIds: [],
       trashItems: [...(state.trashItems ?? []), ...failedObjects],
     }))
+
+    failedObjects.forEach((item) => {
+      const img = new Image()
+      img.src = item.url
+
+      img.onload = () =>
+        set((state) => ({
+          loadedTrashImages: [
+            ...(state.loadedTrashImages ?? []),
+            { ...item, image: img },
+          ],
+        }))
+    })
   },
 })

--- a/stores/trash-store.ts
+++ b/stores/trash-store.ts
@@ -4,7 +4,7 @@ import { Object as IObject } from "@prisma/client"
 import { JsonValue } from "@prisma/client/runtime/client"
 import { ITrashDto } from "@marimo/application/usecases/object/dto/trash-dto"
 
-interface ILoadedTrashImage extends ITrashDto {
+export interface ILoadedTrashImage extends ITrashDto {
   image: HTMLImageElement
 }
 

--- a/utils/rem-to-px.ts
+++ b/utils/rem-to-px.ts
@@ -1,7 +1,7 @@
 export const remToPx = (rem: number, width: number) => {
   if (width < 769) {
-    return 10 * rem
+    return 15 * rem
   }
 
-  return 16 * rem
+  return 19 * rem
 }


### PR DESCRIPTION
#57 

### **기대 현상**
마리모를 드래그 할 때 object와 충돌이 일어나면 isActive가 false로 변경되며, zustand에서 해당 object가 삭제된다

### **실제 발생한 일**
1. object가 잘 제거 되지 않음.
2. 화면에서 쓰레기가 모두 사라져도 마리모가 춤을 추지 않음

### **문제**
1. object에서 isActive로 수정하는 fetch 이벤트가 너무 많이 발생해 fetch가 너무 늦게 되거나, 안되는 문제
2. Maximum update depth exceeded 오류 발생 -> useEffect 내에서 setState를 호출할 때 발생, 지금은 zustand를 useEffect 안에서 호출해서 setState를 하는데, 너무 많이 자주 발생해서 문제가 생기기도 하는듯 -> 이벤트가 발생하는 곳이 많아 정리 필요

### **해결**
- **Object CRUD 개선** : 기존 충돌 이벤트가 발생할 때마다 update 하던 방식에서 마리모와 충돌하여 제거 된 object의 id를 별도로 저장하여 드래그가 끝났을 때 일괄 update 하는 형식으로 개선
- **zustand 사용 방식 변경** : 이벤트 발생이 잦아 get() 매서드 사용 시 현재 state를 찾지 못하는 문제가 있어 set에서 현재 state를 찾아와서 사용하는 방식으로 변경
- **fetchMarimo에서 token으로 마리모를 찾아올 수 있도록 개선** : 기존에는 zustand에 user가 업데이트 될 때 까지 기다렸다 마리모를 fetch하기 때문에 데이터가 오는 속도가 너무 늦어지게 됨. token만으로 마리모를 받아올 수 있도록 개선
- **loadedTrashImages를 store에서 관리하도록 변경** : loadedTrashImages를 zustand에서 관리해 object를 한개씩 업데이트 할 수 있도록하여 화면 깜빡임 개선